### PR TITLE
Add support for additional tracker API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ public function registerBundles()
 }
 ```
 
-
 Usage
 -----
 Somewhere in your views, right before the closing `</body>` tag, insert 
 
 	{{ piwik_code() }}
 
+This will add the appropriate Piwik tracking code as [described in the API reference](http://developer.piwik.org/api-reference/tracking-javascript#where-can-i-find-the-piwik-tracking-code).
 
 Configuration
 -------------
@@ -61,6 +61,28 @@ webfactory_piwik:
     tracker_path: "/js/"
 ```
 
+Add calls to the JavaScript tracker API
+---------------------------------------
+
+The [JavaScript tracking API](http://developer.piwik.org/api-reference/tracking-javascript) provides a lot of methods
+for setting the page name, tracking search results, using custom variables and much more.
+
+The generic `piwik()` function allows you to control the `_paq` variable and add additional API calls to it. For example,
+in your Twig template, you can write
+
+```twig
+    <!-- Somewhere in your HTML, not necessarily at the end -->
+    {{ piwik("setDocumentTitle", document.title) }}
+    {{ piwik("trackGoal", 1) }}
+
+    <!-- Then, at the end: -->
+    {{ piwik_code() }}
+    </body>
+```
+
+Note that when you call `trackSiteSearch`, this will automatically disable the `trackPageView` call made by default.
+This is the [recommended](http://developer.piwik.org/api-reference/tracking-javascript#tracking-internal-search-keywords-categories-and-no-result-search-keywords)
+behaviour.
 
 Credits, Copyright and License
 ------------------------------

--- a/Tests/Twig/ExtensionIntegrationTest.php
+++ b/Tests/Twig/ExtensionIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Twig;
 
+use Symfony\Component\DependencyInjection\Tests\Compiler\CheckExceptionOnInvalidReferenceBehaviorPassTest;
 use Webfactory\Bundle\PiwikBundle\Twig\Extension;
 
 /**
@@ -27,4 +28,22 @@ final class ExtensionIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains((string)$siteId, $output);
         $this->assertContains($hostname, $output);
     }
+
+    public function testCustomApiCallsThroughPiwikFunction()
+    {
+        $twig = new \Twig_Environment(
+            new \Twig_Loader_String(),
+            array('debug' => true, 'cache' => false, 'autoescape' => true, 'optimizations' => 0)
+        );
+
+        $twig->addExtension(new Extension(false, null, null, false));
+
+        $output = $twig->render("
+            {{ piwik('foo', 'bar', 'baz') }}
+            {{ piwik_code() }}
+        ");
+
+        $this->assertContains('["foo","bar","baz"]', $output);
+    }
+
 }

--- a/Tests/Twig/ExtensionTest.php
+++ b/Tests/Twig/ExtensionTest.php
@@ -33,6 +33,29 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($hostname, $extension->piwikCode());
     }
 
+    public function testAdditionalApiCallsCanBeAdded()
+    {
+        $extension = new Extension(false, null, null, false);
+        $extension->piwikPush("foo", "bar", "baz");
+        $this->assertContains('["foo","bar","baz"]', $extension->piwikCode());
+    }
+
+    public function testTrackPageViewEnabledByDefault()
+    {
+        $extension = new Extension(false, null, null, false);
+        $this->assertContains('"trackPageView"', $extension->piwikCode());
+    }
+
+    public function testTrackSiteSearchDisablesPageTracking()
+    {
+        $extension = new Extension(false, null, null, false);
+        $extension->piwikPush('trackSiteSearch', "Banana", "Organic Food", 42);
+
+        $code = $extension->piwikCode();
+        $this->assertContains('"trackSiteSearch"', $code);
+        $this->assertNotContains('"trackPageView"', $code);
+    }
+
     public function testIsTwigExtension()
     {
         $extension = new Extension(false, 1, '', false);


### PR DESCRIPTION
There are quite a few things and settings you can apply to the tracker; see http://developer.piwik.org/api-reference/tracking-javascript.

Of particular interest are user-defined variables. For example, you could push the category of the currently displayed blog post to Piwik to get categories-based analytics.

All those options basically end up as values/arrays in the _paq JavaScript variable.

Now it would be very handy if there was a service so you could write in your controller

``` php
$this->get('piwik.tracker')->push(['trackGoal', 1, $cart->getValue()]);
```

or in Twig

``` twig
{{ piwik_push(['setCustomVariable', 1, "gender", "male", "visit"]) }}
```

Then the bundle could collect all those extra settings and write them out once it renders the piwik_code.
