### PR TITLE
Make the trackerUrl configurable 

### DIFF
--- a/Tests/Twig/ExtensionTest.php
+++ b/Tests/Twig/ExtensionTest.php
@@ -26,6 +26,22 @@ class ExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertContains((string)$siteId, $extension->piwikCode());
     }
 
+    public function testPiwikCodeContainsApiURL() {
+        $siteId = 1;
+        $hostname = 'myHost.de';
+        $path = '/js/';
+        $extension = new Extension(false, $siteId, $hostname, $path);
+        $this->assertContains('_paq.push([\'setAPIUrl\', u]);', $extension->piwikCode());
+    }
+
+    public function testPiwikCodeDoesNotContainApiURL() {
+        $siteId = 1;
+        $hostname = 'myHost.de';
+        $path = 'piwik.php';
+        $extension = new Extension(false, $siteId, $hostname, $path);
+        $this->assertNotContains('_paq.push([\'setAPIUrl\', u]);', $extension->piwikCode());
+    }
+
     public function testPiwikCodeContainsHostName()
     {
         $hostname = 'myHost.de';

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -49,8 +49,15 @@ var _paq = (_paq||[]).concat({$paq});
 
 (function() {
     var u=(("https:" == document.location.protocol) ? "https" : "http") + "://{$this->piwikHost}/";
-    _paq.push(["setTrackerUrl", u+"piwik.php"]);
+    _paq.push(["setTrackerUrl", u+"{$this->trackerPath}"]);
     _paq.push(["setSiteId", "{$this->siteId}"]);
+EOT;
+        if($this->trackerPath !== 'piwik.php') {
+            $piwikCode .= <<<EOT
+    _paq.push(['setAPIUrl', u]);
+EOT;
+        }
+        $piwikCode .= <<<EOT
     var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
     g.defer=true; g.async=true; g.src=u+"{$this->trackerPath}"; s.parentNode.insertBefore(g,s);
 })();


### PR DESCRIPTION
Make the tracker URL configurable so user are free to change the path to piwik.js and piwik.php for both downloading the javascript and sending the analytics requests to the piwik server.