### PR TITLE
Fix Symfony 4.3 deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,8 +9,13 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('webfactory_piwik');
+        $treeBuilder = new TreeBuilder('webfactory_piwik');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('webfactory_piwik');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
It's done the same way as here:
* https://github.com/symfony/maker-bundle/pull/324/commits/560d03cf68e3e9f1b9c
* https://github.com/doctrine/DoctrineBundle/pull/853/commits/e711bed5a82437262a

Fixes #21