### PR TITLE
Disable cookies by default in favor of GDPR.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('piwik_host')->isRequired()->end()
             ->scalarNode('tracker_path')->defaultValue('/js/')->end()
             ->scalarNode('site_id')->isRequired()->end()
-            ->scalarNode('disable_cookies')->defaultValue(true)->end()
+            ->scalarNode('disable_cookies')->defaultValue(null)->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('piwik_host')->isRequired()->end()
             ->scalarNode('tracker_path')->defaultValue('/js/')->end()
             ->scalarNode('site_id')->isRequired()->end()
+            ->scalarNode('disable_cookies')->defaultValue(true)->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/WebfactoryPiwikExtension.php
+++ b/DependencyInjection/WebfactoryPiwikExtension.php
@@ -18,7 +18,7 @@ class WebfactoryPiwikExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id'] as $configParameterKey) {
+        foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id', 'disable_cookies'] as $configParameterKey) {
             $container->setParameter("webfactory_piwik.$configParameterKey", $config[$configParameterKey]);
         }
     }

--- a/DependencyInjection/WebfactoryPiwikExtension.php
+++ b/DependencyInjection/WebfactoryPiwikExtension.php
@@ -18,12 +18,16 @@ class WebfactoryPiwikExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id', 'disable_cookies'] as $configParameterKey) {
-            if ($configParameterKey === 'disable_cookies' && $config[$configParameterKey] === null) {
-                $config[$configParameterKey] = false;
-                @trigger_error('The "disableCookies" configuration key is missing. Please define the "disableCookies" key explicit. In newer versions this will be "true" by default.', E_USER_DEPRECATED);
-            }
+        if ($config['disable_cookies'] === null) {
+            $config['disable_cookies'] = false;
+            @trigger_error(
+                'The "disableCookies" configuration key is missing. In the next major version, it will default to "true". 
+                Please configure the "disableCookies" key explicitly if this is not what you want.',
+                E_USER_DEPRECATED
+            );
+        }
 
+        foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id', 'disable_cookies'] as $configParameterKey) {
             $container->setParameter("webfactory_piwik.$configParameterKey", $config[$configParameterKey]);
         }
     }

--- a/DependencyInjection/WebfactoryPiwikExtension.php
+++ b/DependencyInjection/WebfactoryPiwikExtension.php
@@ -18,7 +18,7 @@ class WebfactoryPiwikExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if ($config['disable_cookies'] === null) {
+        if (null === $config['disable_cookies']) {
             $config['disable_cookies'] = false;
             @trigger_error(
                 'The "disableCookies" configuration key is missing. In the next major version, it will default to "true". 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ You can configure the bundle in your `config.yml`. Full Example:
 webfactory_piwik:
     # Required, no default. Must be set to the site id found in the Matomo control panel
     site_id: 1
-    # Required, has default. Usually, you only want to include the tracking code in a production environment
-    disabled: '%kernel.debug%'
     # Required. no default. Hostname and path to the Matomo host.
     piwik_host: my.piwik.hostname
-    # Required, has default. Path to the tracking script on the host.
+    # Optional, has default. Usually, you only want to include the tracking code in a production environment
+    disabled: '%kernel.debug%'
+    # Optional, has default. Path to the tracking script on the host.
     tracker_path: "/js/"
+    # Optional, has default. Disable cookies in favor of GDPR
+    # https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/ & https://matomo.org/faq/general/faq_157/
+    disable_cookies: true
 ```
 
 Add calls to the JavaScript tracker API

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
             <argument>%webfactory_piwik.site_id%</argument>
             <argument>%webfactory_piwik.piwik_host%</argument>
             <argument>%webfactory_piwik.tracker_path%</argument>
+            <argument>%webfactory_piwik.disable_cookies%</argument>
             <tag name="twig.extension" />
         </service>
 

--- a/Tests/Twig/ExtensionIntegrationTest.php
+++ b/Tests/Twig/ExtensionIntegrationTest.php
@@ -20,7 +20,7 @@ final class ExtensionIntegrationTest extends TestCase
         $siteId = 1;
         $hostname = 'myHost.de';
 
-        $output = $this->renderWithExtension('{{ piwik_code() }}', new Extension(false, $siteId, $hostname, false));
+        $output = $this->renderWithExtension('{{ piwik_code() }}', new Extension(false, $siteId, $hostname, false, true));
 
         $this->assertContains((string) $siteId, $output);
         $this->assertContains($hostname, $output);
@@ -31,7 +31,7 @@ final class ExtensionIntegrationTest extends TestCase
         $output = $this->renderWithExtension("
             {{ piwik('foo', 'bar', 'baz') }}
             {{ piwik_code() }}
-        ", new Extension(false, 1, 'my.host', false));
+        ", new Extension(false, 1, 'my.host', false, true));
 
         $this->assertContains('["foo","bar","baz"]', $output);
     }

--- a/Tests/Twig/ExtensionIntegrationTest.php
+++ b/Tests/Twig/ExtensionIntegrationTest.php
@@ -20,7 +20,7 @@ final class ExtensionIntegrationTest extends TestCase
         $siteId = 1;
         $hostname = 'myHost.de';
 
-        $output = $this->renderWithExtension('{{ piwik_code() }}', new Extension(false, $siteId, $hostname, false, true));
+        $output = $this->renderWithExtension('{{ piwik_code() }}', new Extension(false, $siteId, $hostname, false));
 
         $this->assertContains((string) $siteId, $output);
         $this->assertContains($hostname, $output);
@@ -31,7 +31,7 @@ final class ExtensionIntegrationTest extends TestCase
         $output = $this->renderWithExtension("
             {{ piwik('foo', 'bar', 'baz') }}
             {{ piwik_code() }}
-        ", new Extension(false, 1, 'my.host', false, true));
+        ", new Extension(false, 1, 'my.host', false));
 
         $this->assertContains('["foo","bar","baz"]', $output);
     }

--- a/Tests/Twig/ExtensionTest.php
+++ b/Tests/Twig/ExtensionTest.php
@@ -9,26 +9,26 @@ class ExtensionTest extends TestCase
 {
     public function testPiwikCodeReturnsNoScriptWhenDisabled()
     {
-        $extension = new Extension(true, 1, '', false);
+        $extension = new Extension(true, 1, '', false, true);
         $this->assertNotContains('script', $extension->piwikCode());
     }
 
     public function testPiwikCodeReturnsScript()
     {
-        $extension = new Extension(false, 1, '', false);
+        $extension = new Extension(false, 1, '', false, true);
         $this->assertContains('script', $extension->piwikCode());
     }
 
     public function testPiwikCodeContainsSiteId()
     {
         $siteId = 1234;
-        $extension = new Extension(false, $siteId, '', false);
+        $extension = new Extension(false, $siteId, '', false, true);
         $this->assertContains((string) $siteId, $extension->piwikCode());
     }
 
     public function testPiwikCodeContainsApiURL()
     {
-        $extension = new Extension(false, 1, 'my.host', '/js/');
+        $extension = new Extension(false, 1, 'my.host', '/js/', true);
         $this->assertContains('_paq.push([\'setAPIUrl\', u]);', $extension->piwikCode());
     }
 
@@ -37,33 +37,39 @@ class ExtensionTest extends TestCase
         $siteId = 1;
         $hostname = 'myHost.de';
         $path = 'piwik.php';
-        $extension = new Extension(false, $siteId, $hostname, $path);
+        $extension = new Extension(false, $siteId, $hostname, $path, true);
         $this->assertNotContains('_paq.push([\'setAPIUrl\', u]);', $extension->piwikCode());
     }
 
     public function testPiwikCodeContainsHostName()
     {
         $hostname = 'myHost.de';
-        $extension = new Extension(false, 1, $hostname, false);
+        $extension = new Extension(false, 1, $hostname, false, true);
         $this->assertContains($hostname, $extension->piwikCode());
     }
 
     public function testAdditionalApiCallsCanBeAdded()
     {
-        $extension = new Extension(false, 1, 'my.host', false);
+        $extension = new Extension(false, 1, 'my.host', false, true);
         $extension->piwikPush('foo', 'bar', 'baz');
         $this->assertContains('["foo","bar","baz"]', $extension->piwikCode());
     }
 
     public function testTrackPageViewEnabledByDefault()
     {
-        $extension = new Extension(false, 1, 'my.host', false);
+        $extension = new Extension(false, 1, 'my.host', false, true);
         $this->assertContains('"trackPageView"', $extension->piwikCode());
+    }
+
+    public function testCookiesDisabledByDefault()
+    {
+        $extension = new Extension(false, 1, 'my.host', false, true);
+        $this->assertContains('"disableCookies"', $extension->piwikCode());
     }
 
     public function testTrackSiteSearchDisablesPageTracking()
     {
-        $extension = new Extension(false, 1, 'my.host', false);
+        $extension = new Extension(false, 1, 'my.host', false, true);
         $extension->piwikPush('trackSiteSearch', 'Banana', 'Organic Food', 42);
 
         $code = $extension->piwikCode();
@@ -73,7 +79,7 @@ class ExtensionTest extends TestCase
 
     public function testIsTwigExtension()
     {
-        $extension = new Extension(false, 1, '', false);
+        $extension = new Extension(false, 1, '', false, true);
         $this->assertInstanceOf('\Twig_ExtensionInterface', $extension);
     }
 }

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -37,7 +37,7 @@ class Extension extends AbstractExtension
      */
     private $paqs = [];
 
-    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, bool $disableCookies)
+    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, ?bool $disableCookies)
     {
         $this->disabled = $disabled;
         $this->siteId = $siteId;
@@ -65,11 +65,15 @@ class Extension extends AbstractExtension
             return '<!-- Piwik is disabled due to webfactory_piwik.disabled=true in your configuration -->';
         }
 
+        if ($this->disableCookies === null) {
+            trigger_error('The "disableCookies" configuration key is missing. Please define the "disableCookies" key explicit. In newer versions this will be "true" by default.', E_USER_DEPRECATED);
+        }
+
         /*
          * https://matomo.org/faq/general/faq_157/
          * Call disableCookies before calling trackPageView
          */
-        if ($this->disableCookies) {
+        if ($this->disableCookies === true) {
             $this->paqs[] = ['disableCookies'];
         }
 

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -69,7 +69,7 @@ class Extension extends AbstractExtension
          * https://matomo.org/faq/general/faq_157/
          * Call disableCookies before calling trackPageView
          */
-        if ($this->disableCookies === true) {
+        if (true === $this->disableCookies) {
             $this->paqs[] = ['disableCookies'];
         }
 

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -28,16 +28,22 @@ class Extension extends AbstractExtension
     private $trackerPath;
 
     /**
+     * @var bool
+     */
+    private $disableCookies;
+
+    /**
      * @var array
      */
     private $paqs = [];
 
-    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath)
+    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, bool $disableCookies)
     {
         $this->disabled = $disabled;
         $this->siteId = $siteId;
         $this->piwikHost = rtrim($piwikHost, '/');
         $this->trackerPath = ltrim($trackerPath, '/');
+        $this->disableCookies = $disableCookies;
     }
 
     public function getFunctions()
@@ -57,6 +63,14 @@ class Extension extends AbstractExtension
     {
         if ($this->disabled) {
             return '<!-- Piwik is disabled due to webfactory_piwik.disabled=true in your configuration -->';
+        }
+
+        /*
+         * https://matomo.org/faq/general/faq_157/
+         * Call disableCookies before calling trackPageView
+         */
+        if ($this->disableCookies) {
+            $this->paqs[] = ['disableCookies'];
         }
 
         $this->addDefaultApiCalls();


### PR DESCRIPTION
As of new guidelines by the european commission and other law institutions in different countries, you have to create cookie consent banners for sites which use tracking cookies.

To prevent these banners in advance this new flag should disable cookies.

Further reading:
https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/

https://matomo.org/faq/general/faq_157/