### PR TITLE
Set config key disable_cookies default to true [BC break]

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('piwik_host')->isRequired()->end()
             ->scalarNode('tracker_path')->defaultValue('/js/')->end()
             ->scalarNode('site_id')->isRequired()->end()
-            ->scalarNode('disable_cookies')->defaultValue(null)->end()
+            ->scalarNode('disable_cookies')->defaultValue(true)->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/WebfactoryPiwikExtension.php
+++ b/DependencyInjection/WebfactoryPiwikExtension.php
@@ -18,15 +18,6 @@ class WebfactoryPiwikExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (null === $config['disable_cookies']) {
-            $config['disable_cookies'] = false;
-            @trigger_error(
-                'The "disableCookies" configuration key is missing. In the next major version, it will default to "true". 
-                Please configure the "disableCookies" key explicitly if this is not what you want.',
-                E_USER_DEPRECATED
-            );
-        }
-
         foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id', 'disable_cookies'] as $configParameterKey) {
             $container->setParameter("webfactory_piwik.$configParameterKey", $config[$configParameterKey]);
         }

--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ webfactory_piwik:
     tracker_path: "/js/"
     # Optional, has default. Disable cookies in favor of GDPR
     # https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/ & https://matomo.org/faq/general/faq_157/
-    # 
-    # In the next major release the default will be true!
-    disable_cookies: false
+    disable_cookies: true
 ```
 
 Add calls to the JavaScript tracker API

--- a/Tests/Twig/ExtensionTest.php
+++ b/Tests/Twig/ExtensionTest.php
@@ -63,8 +63,14 @@ class ExtensionTest extends TestCase
 
     public function testCookiesCanBeDisabled()
     {
-        $extension = new Extension(false, 1, 'my.host', false, true);
+        $extension = new Extension(false, 1, 'my.host', false);
         $this->assertContains('"disableCookies"', $extension->piwikCode());
+    }
+
+    public function testCookiesCanBeEnabled()
+    {
+        $extension = new Extension(false, 1, 'my.host', false, false);
+        $this->assertNotContains('"disableCookies"', $extension->piwikCode());
     }
 
     public function testTrackSiteSearchDisablesPageTracking()

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -37,7 +37,7 @@ class Extension extends AbstractExtension
      */
     private $paqs = [];
 
-    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, bool $disableCookies = false)
+    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, bool $disableCookies = true)
     {
         $this->disabled = $disabled;
         $this->siteId = $siteId;


### PR DESCRIPTION
Introduced new BC-break.

The config key `disable_cookies` should be set default to true, because in favor of GDPR.