### PR TITLE
Fix "setDoNotTrack" handling

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('tracker_path')->defaultValue('/js/')->end()
             ->scalarNode('site_id')->isRequired()->end()
             ->scalarNode('disable_cookies')->defaultValue(true)->end()
+            ->scalarNode('enable_do_not_track')->defaultValue(true)->info('Include ["setDoNotTrack", true] in default _paqs')->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/WebfactoryPiwikExtension.php
+++ b/DependencyInjection/WebfactoryPiwikExtension.php
@@ -18,7 +18,7 @@ class WebfactoryPiwikExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id', 'disable_cookies'] as $configParameterKey) {
+        foreach (['disabled', 'piwik_host', 'tracker_path', 'site_id', 'disable_cookies', 'enable_do_not_track'] as $configParameterKey) {
             $container->setParameter("webfactory_piwik.$configParameterKey", $config[$configParameterKey]);
         }
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,7 @@
             <argument>%webfactory_piwik.piwik_host%</argument>
             <argument>%webfactory_piwik.tracker_path%</argument>
             <argument>%webfactory_piwik.disable_cookies%</argument>
+            <argument>%webfactory_piwik.enable_do_not_track%</argument>
             <tag name="twig.extension" />
         </service>
 

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -37,13 +37,17 @@ class Extension extends AbstractExtension
      */
     private $paqs = [];
 
-    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, bool $disableCookies = true)
+    public function __construct(bool $disabled, string $siteId, string $piwikHost, string $trackerPath, bool $disableCookies = true, bool $enableDoNotTrack = true)
     {
         $this->disabled = $disabled;
         $this->siteId = $siteId;
         $this->piwikHost = rtrim($piwikHost, '/');
         $this->trackerPath = ltrim($trackerPath, '/');
         $this->disableCookies = $disableCookies;
+
+        if ($enableDoNotTrack) {
+            $this->paqs[] = ['setDoNotTrack', true];
+        }
     }
 
     public function getFunctions(): array
@@ -81,7 +85,6 @@ class Extension extends AbstractExtension
 <!-- Piwik -->
 <script type="text/javascript">//<![CDATA[
 var _paq = (_paq||[]).concat({$paq});
-_paq.push(["setDoNotTrack", true]);
 (function() {
     var u=(("https:" == document.location.protocol) ? "https" : "http") + "://{$this->piwikHost}/";
     _paq.push(["setTrackerUrl", u+"{$this->trackerPath}"]);


### PR DESCRIPTION
The `setDoNotTrack` configuration value has to be pushed to the `_paq`s _before_ the `trackPageView` setting. `trackPageView` seems to trigger the actual logging request when it is being processed.

With the old state of the code, `setDoNotTrack` was set too late and never became effective. A request to the Matomo server would be sent in any case, relying on the server-side "do not track" privacy feature to be enabled.

This change adds a new `enable_do_not_track` configuration setting which defaults to `true`.

When you set it to `false`, the `setDoNotTrack` command will not be used. You can push it to the `_paq` array yourself, possibly depending on client-side logic. But remember: It has to be in the `_paq` array _before_ the `trackPageView` entry.

