### PR TITLE
Vermeide Deprecation (Case 193321)

### DIFF
--- a/DependencyInjection/WebfactoryPiwikExtension.php
+++ b/DependencyInjection/WebfactoryPiwikExtension.php
@@ -4,8 +4,8 @@ namespace Webfactory\Bundle\PiwikBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WebfactoryPiwikExtension extends Extension
 {


### PR DESCRIPTION
...durch Nutzung von `Symfony\Component\DependencyInjection\Extension\Extension` an Stelle von `Symfony\Component\HttpKernel\DependencyInjection\Extension`.
